### PR TITLE
renamed acl bootstrap bool explicitly

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ module "consul_cluster" {
   instance_type          = var.instance_type
   consul_version         = var.consul_version
   consul_cluster_version = var.consul_cluster_version
-  bootstrap              = var.bootstrap
+  acl_bootstrap_bool     = var.acl_bootstrap_bool
   key_name               = var.key_name
   name_prefix            = var.name_prefix
   vpc_id                 = var.vpc_id

--- a/modules/consul_cluster/main.tf
+++ b/modules/consul_cluster/main.tf
@@ -99,7 +99,7 @@ resource "aws_launch_configuration" "consul_servers" {
       agent_server_token     = random_uuid.consul_agent_server_token.result,
       snapshot_token         = random_uuid.consul_snapshot_token.result,
       consul_cluster_version = var.consul_cluster_version,
-      bootstrap              = var.bootstrap,
+      acl_bootstrap_bool     = var.acl_bootstrap_bool,
       enable_connect         = var.enable_connect,
       consul_config          = var.consul_config,
   })

--- a/modules/consul_cluster/scripts/install_hashitools_consul_server.sh.tpl
+++ b/modules/consul_cluster/scripts/install_hashitools_consul_server.sh.tpl
@@ -81,12 +81,12 @@ EOF
 
 
 %{ if acl_bootstrap_bool }
-cat << EOF > /tmp/acl_bootstrap_bool_tokens.sh
+cat << EOF > /tmp/bootstrap_tokens.sh
 #!/bin/bash
 export CONSUL_HTTP_TOKEN=${master_token}
 echo "Creating Consul ACL policies......"
-if ! consul kv get acl_acl_bootstrap_bool 2>/dev/null; then
-  consul kv put  acl_acl_bootstrap_bool 1
+if ! consul kv get acl_bootstrap 2>/dev/null; then
+  consul kv put  acl_bootstrap 1
 
   echo '
   node_prefix "" {
@@ -136,11 +136,11 @@ if ! consul kv get acl_acl_bootstrap_bool 2>/dev/null; then
   # consul acl token create -description "consul snapshot agent" -policy-name snapshot_agent -secret "${snapshot_token}" 1>/dev/null
   consul acl token update -id anonymous -policy-name anonymous 1>/dev/null
 else
-  echo "acl_bootstrap_bool already completed"
+  echo "Bootstrap already completed"
 fi
 EOF
 
-chmod 700 /tmp/acl_bootstrap_bool_tokens.sh
+chmod 700 /tmp/bootstrap_tokens.sh
 
 %{ endif }
 
@@ -197,5 +197,5 @@ until [[ $LEADER -eq 1 ]]; do
     sleep 2
 done
 
-%{ if acl_bootstrap_bool }/tmp/acl_bootstrap_bool_tokens.sh%{ endif }
+%{ if acl_bootstrap_bool }/tmp/bootstrap_tokens.sh%{ endif }
 echo "$INSTANCE_ID determined all nodes to be healthy and ready to go <3"

--- a/modules/consul_cluster/scripts/install_hashitools_consul_server.sh.tpl
+++ b/modules/consul_cluster/scripts/install_hashitools_consul_server.sh.tpl
@@ -42,10 +42,10 @@ performance {
 
 acl {
   enabled        = true
-  %{ if bootstrap }default_policy = "allow"%{ else }default_policy = "deny"%{ endif }
+  %{ if acl_bootstrap_bool }default_policy = "allow"%{ else }default_policy = "deny"%{ endif }
   enable_token_persistence = true
   tokens {
-    master = "${master_token}"%{ if !bootstrap }
+    master = "${master_token}"%{ if !acl_bootstrap_bool }
     agent  = "${agent_server_token}"%{ endif }
   }
 }
@@ -80,13 +80,13 @@ EOF
 %{ endif }
 
 
-%{ if bootstrap }
-cat << EOF > /tmp/bootstrap_tokens.sh
+%{ if acl_bootstrap_bool }
+cat << EOF > /tmp/acl_bootstrap_bool_tokens.sh
 #!/bin/bash
 export CONSUL_HTTP_TOKEN=${master_token}
 echo "Creating Consul ACL policies......"
-if ! consul kv get acl_bootstrap 2>/dev/null; then
-  consul kv put  acl_bootstrap 1
+if ! consul kv get acl_acl_bootstrap_bool 2>/dev/null; then
+  consul kv put  acl_acl_bootstrap_bool 1
 
   echo '
   node_prefix "" {
@@ -136,11 +136,11 @@ if ! consul kv get acl_bootstrap 2>/dev/null; then
   # consul acl token create -description "consul snapshot agent" -policy-name snapshot_agent -secret "${snapshot_token}" 1>/dev/null
   consul acl token update -id anonymous -policy-name anonymous 1>/dev/null
 else
-  echo "Bootstrap already completed"
+  echo "acl_bootstrap_bool already completed"
 fi
 EOF
 
-chmod 700 /tmp/bootstrap_tokens.sh
+chmod 700 /tmp/acl_bootstrap_bool_tokens.sh
 
 %{ endif }
 
@@ -197,5 +197,5 @@ until [[ $LEADER -eq 1 ]]; do
     sleep 2
 done
 
-%{ if bootstrap }/tmp/bootstrap_tokens.sh%{ endif }
+%{ if acl_bootstrap_bool }/tmp/acl_bootstrap_bool_tokens.sh%{ endif }
 echo "$INSTANCE_ID determined all nodes to be healthy and ready to go <3"

--- a/modules/consul_cluster/variables.tf
+++ b/modules/consul_cluster/variables.tf
@@ -1,12 +1,12 @@
+variable "acl_bootstrap_bool" {
+  type        = bool
+  default     = true
+  description = "Initial ACL Bootstrap configurations"
+}
+
 variable "allowed_inbound_cidrs" {
   type        = list(string)
   description = "List of CIDR blocks to permit inbound Consul access from"
-}
-
-variable "bootstrap" {
-  type        = bool
-  default     = true
-  description = "Initial Bootstrap configurations"
 }
 
 variable "consul_clients" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,12 +1,12 @@
+variable "acl_bootstrap_bool" {
+  type        = bool
+  default     = true
+  description = "Initial ACL Bootstrap configurations"
+}
+
 variable "allowed_inbound_cidrs" {
   type        = list(string)
   description = "List of CIDR blocks to permit inbound Consul access from"
-}
-
-variable "bootstrap" {
-  type        = bool
-  default     = true
-  description = "Initial Bootstrap configurations"
 }
 
 variable "consul_clients" {


### PR DESCRIPTION
This PR renames the `bootstrap` var to `acl_bootstrap_bool` in an effort to be more explicit in naming.