### PR TITLE
remove epoch from package installation

### DIFF
--- a/modules/consul_cluster/scripts/install_hashitools_consul_client.sh.tpl
+++ b/modules/consul_cluster/scripts/install_hashitools_consul_client.sh.tpl
@@ -5,7 +5,7 @@
 curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add -
 apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
 apt-get update
-apt-get install -y consul=1:${consul_version}
+apt-get install -y consul=${consul_version}
 
 echo "Configuring system time"
 timedatectl set-timezone UTC

--- a/modules/consul_cluster/scripts/install_hashitools_consul_server.sh.tpl
+++ b/modules/consul_cluster/scripts/install_hashitools_consul_server.sh.tpl
@@ -5,7 +5,7 @@
 curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add -
 apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
 apt-get update
-apt-get install -y consul=1:${consul_version}
+apt-get install -y consul=${consul_version}
 
 echo "Installing jq"
 curl --silent -Lo /bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64


### PR DESCRIPTION
The linux package index was regenerated without an epoch so the old command to install the `consul` package now references an invalid version. 

This is actually a breaking change for anyone using any previous versions of the module. 