### PR TITLE
Add ami_id base image override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.1.4 (July 22, 2020)
+
+IMPROVEMENTS:
+
+* installation: updated package epoch for regenerated repository
+
 ## 0.1.3 (July 10, 2020)
 
 IMPROVEMENTS:

--- a/modules/consul_cluster/main.tf
+++ b/modules/consul_cluster/main.tf
@@ -82,7 +82,7 @@ resource "aws_autoscaling_group" "consul_servers" {
 # provides a resource for a new autoscaling group launch configuration
 resource "aws_launch_configuration" "consul_servers" {
   name            = "${random_id.environment_name.hex}-consul-servers-${var.consul_cluster_version}"
-  image_id        = data.aws_ami.ubuntu.id
+  image_id        = var.ami_id == "" ? data.aws_ami.ubuntu.id : var.ami_id
   instance_type   = var.instance_type
   key_name        = var.key_name
   security_groups = [aws_security_group.consul.id]

--- a/modules/consul_cluster/variables.tf
+++ b/modules/consul_cluster/variables.tf
@@ -79,3 +79,9 @@ variable "public_ip" {
   default     = false
   description = "should ec2 instance have public ip?"
 }
+
+variable "ami_id" {
+  type = string
+  default = ""
+  description = "EC2 instance AMI ID to override the default Ubuntu AMI"
+}

--- a/modules/consul_cluster/variables.tf
+++ b/modules/consul_cluster/variables.tf
@@ -1,68 +1,81 @@
+# Required Parameters
+variable "allowed_inbound_cidrs" {
+  type        = list(string)
+  description = "List of CIDR blocks to permit inbound Consul access from"
+}
+
+variable "consul_version" {
+  type = string
+  description = "Consul version to install"
+}
+
+variable "name_prefix" {
+  type = string
+  description = "prefix used in resource names"
+}
+
+variable "owner" {
+  type = string
+  description = "value of owner tag on EC2 instances"
+}
+
+
+variable "vpc_id" {
+  type = string
+  description = "VPC ID"
+}
+
+# Optional Parameters
 variable "acl_bootstrap_bool" {
   type        = bool
   default     = true
   description = "Initial ACL Bootstrap configurations"
 }
 
-variable "allowed_inbound_cidrs" {
-  type        = list(string)
-  description = "List of CIDR blocks to permit inbound Consul access from"
-}
-
 variable "consul_clients" {
+  type = number
   default     = "3"
   description = "number of Consul instances"
 }
 
 variable "consul_config" {
-  description = "HCL Object with additional configuration overrides supplied to the consul servers.  This is converted to JSON before rendering via the template."
+  type = map(string)
   default     = {}
+  description = "HCL Object with additional configuration overrides supplied to the consul servers.  This is converted to JSON before rendering via the template."
 }
 
 variable "consul_cluster_version" {
+  type = string
   default     = "0.0.1"
   description = "Custom Version Tag for Upgrade Migrations"
 }
 
 variable "consul_servers" {
+  type = number
   default     = "5"
   description = "number of Consul instances"
 }
 
-variable "consul_version" {
-  description = "Consul version"
-}
-
 variable "enable_connect" {
   type        = bool
-  description = "Whether Consul Connect should be enabled on the cluster"
   default     = false
+  description = "Whether Consul Connect should be enabled on the cluster"
 }
 
 variable "instance_type" {
+  type = string
   default     = "m5.large"
   description = "Instance type for Consul instances"
 }
 
 variable "key_name" {
+  type = string
   default     = "default"
   description = "SSH key name for Consul instances"
-}
-
-variable "name_prefix" {
-  description = "prefix used in resource names"
-}
-
-variable "owner" {
-  description = "value of owner tag on EC2 instances"
 }
 
 variable "public_ip" {
   type        = bool
   default     = false
   description = "should ec2 instance have public ip?"
-}
-
-variable "vpc_id" {
-  description = "VPC ID"
 }


### PR DESCRIPTION
One use case I ran into is adding telemetry to the Consul configuration which is enabled through `consul_config`. This is great but if I wanted to add Datadog to my instances, there isn't a way to actually install the datadog package through the current userdata scripts.

This PR will allow users to pass in an `ami_id` override that can be used in place of the vanilla ubuntu base image as the AMI the Consul instances will use. In my case, this will allow me to install the datadog agent in an AMI and then use that AMI to complete the Consul setup process by running the userdata script afterwards. 

I have also done a bit of cleanup of the variable file to make it cleaner to look through and a CHANGELOG.md update to include the latest release. 